### PR TITLE
Sync anki feedback to database

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ dependencies = [
     "requests>=2.31.0",
     "pydantic (>=2.11.7,<3.0.0)",
     "aiosqlite>=0.21.0",
+    "aiohttp>=3.10.0",
 ]
 
 [project.scripts]

--- a/run_tests.py
+++ b/run_tests.py
@@ -1,0 +1,35 @@
+#!/usr/bin/env python3
+"""Simple test runner script for gpt-to-anki tests."""
+import subprocess
+import sys
+import os
+
+def main():
+    """Run the test suite with appropriate settings."""
+    # Ensure we're in the project root
+    project_root = os.path.dirname(os.path.abspath(__file__))
+    os.chdir(project_root)
+    
+    # Build the pytest command
+    cmd = [
+        sys.executable, "-m", "pytest",
+        "tests/",
+        "-v",  # Verbose output
+        "--tb=short",  # Shorter traceback format
+        "--asyncio-mode=auto",  # Auto-detect async tests
+    ]
+    
+    # Add any command line arguments passed to this script
+    if len(sys.argv) > 1:
+        cmd.extend(sys.argv[1:])
+    
+    print(f"Running: {' '.join(cmd)}")
+    print("-" * 50)
+    
+    # Run the tests
+    result = subprocess.run(cmd)
+    
+    return result.returncode
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/gpt_to_anki/anki_base.py
+++ b/src/gpt_to_anki/anki_base.py
@@ -1,0 +1,13 @@
+from abc import ABC, abstractmethod
+from typing import List
+
+from gpt_to_anki.anki_models import AnkiNoteFeedback
+
+
+class AbstractAnkiDeck(ABC):
+    @abstractmethod
+    async def aget_feedback_for_database_ids(
+        self, database_ids: List[int]
+    ) -> List[AnkiNoteFeedback]:
+        """Fetch latest Anki-side note fields and card state for given database ids."""
+        raise NotImplementedError

--- a/src/gpt_to_anki/anki_connect.py
+++ b/src/gpt_to_anki/anki_connect.py
@@ -1,0 +1,95 @@
+import asyncio
+from typing import Dict, List, Optional
+
+import requests
+
+from gpt_to_anki.anki_base import AbstractAnkiDeck
+from gpt_to_anki.anki_models import AnkiNoteFeedback
+
+
+class AnkiConnectDeck(AbstractAnkiDeck):
+    def __init__(
+        self,
+        deck_name: str,
+        model_name: str,
+        id_field: str = "id",
+        field_map: Optional[Dict[str, str]] = None,
+        endpoint: str = "http://127.0.0.1:8765",
+    ) -> None:
+        self.deck_name = deck_name
+        self.model_name = model_name
+        self.id_field = id_field
+        self.field_map = field_map or {
+            "question": "Question",
+            "answer": "Answer",
+            "topic": "Topic",
+        }
+        self.endpoint = endpoint
+
+    def _post(self, action: str, **params):
+        payload = {"action": action, "version": 6, "params": params}
+        response = requests.post(self.endpoint, json=payload, timeout=30)
+        response.raise_for_status()
+        data = response.json()
+        if data.get("error"):
+            raise RuntimeError(f"AnkiConnect error: {data['error']}")
+        return data.get("result")
+
+    def _build_search_for_id(self, db_id: int) -> str:
+        # Restrict by deck, note type and match the id field
+        return f'deck:"{self.deck_name}" note:"{self.model_name}" {self.id_field}:{db_id}'
+
+    def _fetch_single_feedback(self, db_id: int) -> Optional[AnkiNoteFeedback]:
+        query = self._build_search_for_id(db_id)
+
+        note_ids = self._post("findNotes", query=query) or []
+        if not note_ids:
+            return None
+
+        # Take first note (should be unique by id field)
+        notes = self._post("notesInfo", notes=note_ids) or []
+        if not notes:
+            return None
+
+        note = notes[0]
+        fields = note.get("fields", {})
+
+        def get_field(key: str) -> str:
+            name = self.field_map.get(key, key)
+            value_obj = fields.get(name) or {}
+            return value_obj.get("value", "")
+
+        # Determine suspended/flag from cards
+        card_ids = self._post("findCards", query=query) or []
+        suspended = False
+        flag = 0
+        if card_ids:
+            cards = self._post("cardsInfo", cards=card_ids) or []
+            for card in cards:
+                # Either explicit suspended, or queue == -1
+                if card.get("suspended") or card.get("queue") == -1:
+                    suspended = True
+                try:
+                    flag_value = int(card.get("flags", 0) or 0)
+                except Exception:
+                    flag_value = 0
+                flag = max(flag, flag_value)
+
+        return AnkiNoteFeedback(
+            id=db_id,
+            anki_note_id=note.get("noteId"),
+            deck_name=self.deck_name,
+            model_name=note.get("modelName", self.model_name),
+            question=get_field("question"),
+            answer=get_field("answer"),
+            topic=get_field("topic"),
+            suspended=suspended,
+            flag=flag,
+        )
+
+    async def aget_feedback_for_database_ids(
+        self, database_ids: List[int]
+    ) -> List[AnkiNoteFeedback]:
+        tasks = [asyncio.to_thread(self._fetch_single_feedback, db_id) for db_id in database_ids]
+        results = await asyncio.gather(*tasks)
+        return [r for r in results if r is not None]

--- a/src/gpt_to_anki/anki_models.py
+++ b/src/gpt_to_anki/anki_models.py
@@ -1,0 +1,22 @@
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class AnkiNoteFeedback(BaseModel):
+    model_config = ConfigDict(populate_by_name=True, from_attributes=True)
+
+    # Database/card identity
+    database_id: int = Field(..., alias="id", serialization_alias="id")
+    anki_note_id: int
+
+    # Provenance
+    deck_name: str
+    model_name: str
+
+    # Fields that may have been changed by the user in Anki
+    question: str
+    answer: str
+    topic: str = ""
+
+    # Card state in Anki
+    suspended: bool = False
+    flag: int = 0

--- a/src/gpt_to_anki/anki_sync.py
+++ b/src/gpt_to_anki/anki_sync.py
@@ -1,0 +1,27 @@
+from typing import List
+
+from gpt_to_anki.anki_base import AbstractAnkiDeck
+from gpt_to_anki.database import CardDatabase
+
+
+async def sync_feedback_for_context(
+    deck: AbstractAnkiDeck, db: CardDatabase, context: str
+) -> int:
+    """Fetch feedback from Anki for all cards in a context and persist it.
+
+    Returns number of feedback rows saved.
+    """
+    cards = await db.aload_cards(context)
+    if not cards:
+        return 0
+
+    database_ids: List[int] = [c.database_id for c in cards if c.database_id is not None]
+    if not database_ids:
+        return 0
+
+    feedback = await deck.aget_feedback_for_database_ids(database_ids)
+    if not feedback:
+        return 0
+
+    await db.asave_anki_feedback(feedback)
+    return len(feedback)

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,78 @@
+# Tests for GPT-to-Anki
+
+This directory contains unit and integration tests for the Anki feedback synchronization feature.
+
+## Test Structure
+
+- `unit/` - Unit tests for individual components
+  - `test_anki_base.py` - Tests for the AbstractAnkiDeck interface
+  - `test_anki_connect.py` - Tests for AnkiConnectDeck implementation using aiohttp
+  - `test_anki_models.py` - Tests for AnkiNoteFeedback Pydantic model
+  - `test_database_anki_feedback.py` - Tests for anki_feedback database operations
+  
+- `integration/` - Integration tests
+  - `test_anki_sync_integration.py` - Tests for the complete sync flow
+
+## Running Tests
+
+### Install Test Dependencies
+
+First, ensure you have the development dependencies installed:
+
+```bash
+pip install -e ".[dev]"
+# or with uv:
+uv pip install -e ".[dev]"
+```
+
+### Run All Tests
+
+```bash
+pytest tests/
+```
+
+### Run Specific Test Categories
+
+```bash
+# Unit tests only
+pytest tests/unit/
+
+# Integration tests only  
+pytest tests/integration/
+
+# Specific test file
+pytest tests/unit/test_anki_connect.py
+
+# Specific test class or function
+pytest tests/unit/test_anki_connect.py::TestAnkiConnectDeck::test_post_success
+```
+
+### Run with Coverage
+
+```bash
+pytest tests/ --cov=src/gpt_to_anki --cov-report=html
+```
+
+### Run with Verbose Output
+
+```bash
+pytest tests/ -v
+```
+
+## Test Requirements
+
+The tests use:
+- `pytest` - Test framework
+- `pytest-asyncio` - For testing async code
+- `aiohttp` - For mocking HTTP requests
+- SQLite (in-memory) - For database tests
+
+## Key Test Features
+
+1. **AnkiConnectDeck Tests**: Mock aiohttp responses to test AnkiConnect API interactions without requiring a running Anki instance.
+
+2. **Database Tests**: Use temporary SQLite databases to test persistence operations.
+
+3. **Integration Tests**: Test the complete flow from fetching Anki data to storing in the database.
+
+4. **Async Support**: All async operations are properly tested using pytest-asyncio.

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,1 @@
+# Tests for gpt-to-anki

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,17 @@
+"""Pytest configuration for gpt-to-anki tests."""
+import pytest
+import asyncio
+import sys
+from pathlib import Path
+
+# Add src to Python path
+src_path = Path(__file__).parent.parent / "src"
+sys.path.insert(0, str(src_path))
+
+
+@pytest.fixture(scope="session")
+def event_loop():
+    """Create an instance of the default event loop for the test session."""
+    loop = asyncio.get_event_loop_policy().new_event_loop()
+    yield loop
+    loop.close()

--- a/tests/integration/__init__.py
+++ b/tests/integration/__init__.py
@@ -1,0 +1,1 @@
+# Integration tests

--- a/tests/integration/test_anki_sync_integration.py
+++ b/tests/integration/test_anki_sync_integration.py
@@ -1,0 +1,288 @@
+"""Integration tests for Anki feedback synchronization."""
+import pytest
+import tempfile
+import os
+from unittest.mock import patch, AsyncMock
+
+from gpt_to_anki.anki_connect import AnkiConnectDeck
+from gpt_to_anki.database import CardDatabase
+from gpt_to_anki.anki_models import AnkiNoteFeedback
+
+
+class TestAnkiSyncIntegration:
+    """Integration test suite for Anki feedback synchronization."""
+
+    @pytest.fixture
+    async def db(self):
+        """Create a temporary database for testing."""
+        with tempfile.NamedTemporaryFile(suffix=".db", delete=False) as tmp:
+            db_path = tmp.name
+        
+        db = CardDatabase(db_path)
+        await db.ainit_database()
+        yield db
+        await db.aclose()
+        
+        # Cleanup
+        if os.path.exists(db_path):
+            os.unlink(db_path)
+
+    @pytest.fixture
+    def deck(self):
+        """Create an AnkiConnectDeck instance."""
+        return AnkiConnectDeck(
+            deck_name="TestDeck",
+            model_name="TestModel",
+            id_field="id",
+            field_map={
+                "question": "Front",
+                "answer": "Back",
+                "topic": "Topic",
+            },
+        )
+
+    @pytest.mark.asyncio
+    async def test_full_sync_flow(self, db, deck):
+        """Test the complete flow: fetch from Anki -> save to database -> load from database."""
+        # Mock AnkiConnect responses
+        with patch.object(deck, '_post') as mock_post:
+            # Setup mock responses for 3 different cards
+            def mock_post_side_effect(action, **params):
+                if action == "findNotes":
+                    query = params.get("query", "")
+                    if "id:1" in query:
+                        return [10001]
+                    elif "id:2" in query:
+                        return [10002]
+                    elif "id:3" in query:
+                        return []  # Not found in Anki
+                    return []
+                
+                elif action == "notesInfo":
+                    note_ids = params.get("notes", [])
+                    if 10001 in note_ids:
+                        return [{
+                            "noteId": 10001,
+                            "modelName": "TestModel",
+                            "fields": {
+                                "Front": {"value": "What is Python?"},
+                                "Back": {"value": "A programming language"},
+                                "Topic": {"value": "Programming"}
+                            }
+                        }]
+                    elif 10002 in note_ids:
+                        return [{
+                            "noteId": 10002,
+                            "modelName": "TestModel",
+                            "fields": {
+                                "Front": {"value": "What is async/await?"},
+                                "Back": {"value": "Asynchronous programming syntax"},
+                                "Topic": {"value": "Python"}
+                            }
+                        }]
+                    return []
+                
+                elif action == "findCards":
+                    query = params.get("query", "")
+                    if "id:1" in query:
+                        return [20001, 20002]
+                    elif "id:2" in query:
+                        return [20003]
+                    return []
+                
+                elif action == "cardsInfo":
+                    card_ids = params.get("cards", [])
+                    if 20001 in card_ids or 20002 in card_ids:
+                        return [
+                            {"suspended": False, "queue": 1, "flags": 0},
+                            {"suspended": True, "queue": -1, "flags": 2}
+                        ]
+                    elif 20003 in card_ids:
+                        return [{"suspended": False, "queue": 2, "flags": 1}]
+                    return []
+            
+            mock_post.side_effect = mock_post_side_effect
+            
+            # Fetch feedback from Anki
+            feedback_list = await deck.aget_feedback_for_database_ids([1, 2, 3])
+            
+            # Should get 2 results (ID 3 not found in Anki)
+            assert len(feedback_list) == 2
+            
+            # Verify first feedback
+            fb1 = next(fb for fb in feedback_list if fb.database_id == 1)
+            assert fb1.anki_note_id == 10001
+            assert fb1.question == "What is Python?"
+            assert fb1.answer == "A programming language"
+            assert fb1.topic == "Programming"
+            assert fb1.suspended is True  # One card is suspended
+            assert fb1.flag == 2  # Max flag value
+            
+            # Verify second feedback
+            fb2 = next(fb for fb in feedback_list if fb.database_id == 2)
+            assert fb2.anki_note_id == 10002
+            assert fb2.question == "What is async/await?"
+            assert fb2.answer == "Asynchronous programming syntax"
+            assert fb2.topic == "Python"
+            assert fb2.suspended is False
+            assert fb2.flag == 1
+        
+        # Save to database
+        await db.asave_anki_feedback(feedback_list)
+        
+        # Load from database
+        loaded = await db.aload_anki_feedback([1, 2, 3])
+        assert len(loaded) == 2  # Only 2 were saved
+        
+        # Verify loaded data matches
+        loaded_fb1 = next(fb for fb in loaded if fb.database_id == 1)
+        assert loaded_fb1.question == "What is Python?"
+        assert loaded_fb1.suspended is True
+        
+        loaded_fb2 = next(fb for fb in loaded if fb.database_id == 2)
+        assert loaded_fb2.question == "What is async/await?"
+        assert loaded_fb2.suspended is False
+        
+        await deck.close()
+
+    @pytest.mark.asyncio
+    async def test_sync_with_updates(self, db, deck):
+        """Test syncing updates from Anki to existing database records."""
+        # Initial feedback
+        initial_feedback = [
+            AnkiNoteFeedback(
+                database_id=1,
+                anki_note_id=10001,
+                deck_name="TestDeck",
+                model_name="TestModel",
+                question="Old Question",
+                answer="Old Answer",
+                topic="Old Topic",
+                suspended=False,
+                flag=0,
+            )
+        ]
+        await db.asave_anki_feedback(initial_feedback)
+        
+        # Mock updated data from Anki
+        with patch.object(deck, '_post') as mock_post:
+            mock_post.side_effect = [
+                [10001],  # findNotes
+                [{  # notesInfo - user edited in Anki
+                    "noteId": 10001,
+                    "modelName": "TestModel",
+                    "fields": {
+                        "Front": {"value": "Updated Question in Anki"},
+                        "Back": {"value": "Updated Answer in Anki"},
+                        "Topic": {"value": "Updated Topic"}
+                    }
+                }],
+                [20001],  # findCards
+                [{  # cardsInfo - user suspended the card
+                    "suspended": True,
+                    "queue": -1,
+                    "flags": 3
+                }]
+            ]
+            
+            # Fetch updated feedback
+            updated_feedback = await deck.aget_feedback_for_database_ids([1])
+            assert len(updated_feedback) == 1
+            
+            fb = updated_feedback[0]
+            assert fb.question == "Updated Question in Anki"
+            assert fb.answer == "Updated Answer in Anki"
+            assert fb.topic == "Updated Topic"
+            assert fb.suspended is True
+            assert fb.flag == 3
+        
+        # Save updates to database
+        await db.asave_anki_feedback(updated_feedback)
+        
+        # Verify updates persisted
+        loaded = await db.aload_anki_feedback([1])
+        assert len(loaded) == 1
+        assert loaded[0].question == "Updated Question in Anki"
+        assert loaded[0].suspended is True
+        assert loaded[0].flag == 3
+        
+        await deck.close()
+
+    @pytest.mark.asyncio
+    async def test_sync_error_handling(self, deck):
+        """Test error handling during sync operations."""
+        # Test network error
+        with patch.object(deck, '_post') as mock_post:
+            mock_post.side_effect = RuntimeError("AnkiConnect error: collection is not available")
+            
+            feedback = await deck.aget_feedback_for_database_ids([1])
+            assert len(feedback) == 0  # Should return empty list on error
+        
+        await deck.close()
+
+    @pytest.mark.asyncio  
+    async def test_sync_mixed_results(self, db, deck):
+        """Test syncing when some cards exist in Anki and others don't."""
+        # Mock responses where only some IDs exist in Anki
+        with patch.object(deck, '_post') as mock_post:
+            def mock_post_side_effect(action, **params):
+                if action == "findNotes":
+                    query = params.get("query", "")
+                    if "id:1" in query:
+                        return [10001]
+                    elif "id:2" in query:
+                        return []  # Not in Anki
+                    elif "id:3" in query:
+                        return [10003]
+                    return []
+                
+                elif action == "notesInfo":
+                    note_ids = params.get("notes", [])
+                    result = []
+                    if 10001 in note_ids:
+                        result.append({
+                            "noteId": 10001,
+                            "fields": {
+                                "Front": {"value": "Card 1"},
+                                "Back": {"value": "Answer 1"},
+                                "Topic": {"value": "Topic 1"}
+                            }
+                        })
+                    if 10003 in note_ids:
+                        result.append({
+                            "noteId": 10003,
+                            "fields": {
+                                "Front": {"value": "Card 3"},
+                                "Back": {"value": "Answer 3"}, 
+                                "Topic": {"value": "Topic 3"}
+                            }
+                        })
+                    return result
+                
+                elif action == "findCards":
+                    return []  # No cards for simplicity
+                
+                return []
+            
+            mock_post.side_effect = mock_post_side_effect
+            
+            # Try to sync 3 IDs, but only 2 exist in Anki
+            feedback = await deck.aget_feedback_for_database_ids([1, 2, 3])
+            assert len(feedback) == 2
+            
+            db_ids = [fb.database_id for fb in feedback]
+            assert 1 in db_ids
+            assert 2 not in db_ids  # Skipped
+            assert 3 in db_ids
+        
+        # Save to database
+        await db.asave_anki_feedback(feedback)
+        
+        # Verify only existing ones saved
+        loaded = await db.aload_anki_feedback([1, 2, 3])
+        assert len(loaded) == 2
+        assert any(fb.database_id == 1 for fb in loaded)
+        assert not any(fb.database_id == 2 for fb in loaded)
+        assert any(fb.database_id == 3 for fb in loaded)
+        
+        await deck.close()

--- a/tests/unit/__init__.py
+++ b/tests/unit/__init__.py
@@ -1,0 +1,1 @@
+# Unit tests

--- a/tests/unit/test_anki_base.py
+++ b/tests/unit/test_anki_base.py
@@ -1,0 +1,76 @@
+"""Unit tests for AnkiDeck abstract interface."""
+import pytest
+from typing import List
+
+from gpt_to_anki.anki_base import AbstractAnkiDeck
+from gpt_to_anki.anki_models import AnkiNoteFeedback
+
+
+class MockAnkiDeck(AbstractAnkiDeck):
+    """Mock implementation of AbstractAnkiDeck for testing."""
+    
+    def __init__(self, feedback_data: List[AnkiNoteFeedback]):
+        self.feedback_data = feedback_data
+        self.call_count = 0
+    
+    async def aget_feedback_for_database_ids(
+        self, database_ids: List[int]
+    ) -> List[AnkiNoteFeedback]:
+        """Return mock feedback data."""
+        self.call_count += 1
+        return [f for f in self.feedback_data if f.database_id in database_ids]
+
+
+class TestAbstractAnkiDeck:
+    """Test suite for AbstractAnkiDeck interface."""
+    
+    def test_abstract_class_cannot_be_instantiated(self):
+        """Test that AbstractAnkiDeck cannot be instantiated directly."""
+        with pytest.raises(TypeError):
+            AbstractAnkiDeck()
+    
+    @pytest.mark.asyncio
+    async def test_mock_implementation(self):
+        """Test that mock implementation works correctly."""
+        feedback1 = AnkiNoteFeedback(
+            database_id=1,
+            anki_note_id=10001,
+            deck_name="TestDeck",
+            model_name="TestModel",
+            question="Q1",
+            answer="A1",
+            topic="T1",
+            suspended=False,
+            flag=0
+        )
+        feedback2 = AnkiNoteFeedback(
+            database_id=2,
+            anki_note_id=10002,
+            deck_name="TestDeck",
+            model_name="TestModel",
+            question="Q2",
+            answer="A2",
+            topic="T2",
+            suspended=True,
+            flag=1
+        )
+        
+        mock_deck = MockAnkiDeck([feedback1, feedback2])
+        
+        # Test getting all feedback
+        results = await mock_deck.aget_feedback_for_database_ids([1, 2])
+        assert len(results) == 2
+        assert results[0] == feedback1
+        assert results[1] == feedback2
+        
+        # Test getting partial feedback
+        results = await mock_deck.aget_feedback_for_database_ids([1])
+        assert len(results) == 1
+        assert results[0] == feedback1
+        
+        # Test getting no feedback
+        results = await mock_deck.aget_feedback_for_database_ids([3, 4])
+        assert len(results) == 0
+        
+        # Verify method was called
+        assert mock_deck.call_count == 3

--- a/tests/unit/test_anki_connect.py
+++ b/tests/unit/test_anki_connect.py
@@ -1,0 +1,275 @@
+"""Unit tests for AnkiConnectDeck class."""
+import pytest
+from unittest.mock import AsyncMock, patch, MagicMock
+import aiohttp
+
+from gpt_to_anki.anki_connect import AnkiConnectDeck
+from gpt_to_anki.anki_models import AnkiNoteFeedback
+
+
+class TestAnkiConnectDeck:
+    """Test suite for AnkiConnectDeck class."""
+
+    @pytest.fixture
+    def deck(self):
+        """Create an AnkiConnectDeck instance for testing."""
+        return AnkiConnectDeck(
+            deck_name="TestDeck",
+            model_name="TestModel",
+            id_field="id",
+            field_map={
+                "question": "Front",
+                "answer": "Back",
+                "topic": "Topic",
+            },
+            endpoint="http://127.0.0.1:8765",
+        )
+
+    @pytest.mark.asyncio
+    async def test_init(self, deck):
+        """Test AnkiConnectDeck initialization."""
+        assert deck.deck_name == "TestDeck"
+        assert deck.model_name == "TestModel"
+        assert deck.id_field == "id"
+        assert deck.field_map["question"] == "Front"
+        assert deck.field_map["answer"] == "Back"
+        assert deck.field_map["topic"] == "Topic"
+        assert deck.endpoint == "http://127.0.0.1:8765"
+        assert deck._session is None
+
+    @pytest.mark.asyncio
+    async def test_ensure_session(self, deck):
+        """Test _ensure_session creates a session when needed."""
+        session = await deck._ensure_session()
+        assert isinstance(session, aiohttp.ClientSession)
+        assert deck._session is session
+        
+        # Test it returns existing session
+        session2 = await deck._ensure_session()
+        assert session2 is session
+        
+        await deck.close()
+
+    @pytest.mark.asyncio
+    async def test_context_manager(self, deck):
+        """Test async context manager functionality."""
+        async with deck as d:
+            assert d is deck
+            assert deck._session is not None
+            assert not deck._session.closed
+        
+        # Session should be closed after context exit
+        assert deck._session.closed
+
+    @pytest.mark.asyncio
+    async def test_post_success(self, deck):
+        """Test successful _post method."""
+        mock_response = AsyncMock()
+        mock_response.json = AsyncMock(return_value={"result": "test_result", "error": None})
+        mock_response.raise_for_status = MagicMock()
+        
+        with patch.object(aiohttp.ClientSession, 'post') as mock_post:
+            mock_post.return_value.__aenter__.return_value = mock_response
+            
+            result = await deck._post("testAction", param1="value1")
+            
+            assert result == "test_result"
+            mock_post.assert_called_once()
+            call_args = mock_post.call_args
+            assert call_args[0][0] == "http://127.0.0.1:8765"
+            assert call_args[1]["json"]["action"] == "testAction"
+            assert call_args[1]["json"]["version"] == 6
+            assert call_args[1]["json"]["params"]["param1"] == "value1"
+        
+        await deck.close()
+
+    @pytest.mark.asyncio
+    async def test_post_error(self, deck):
+        """Test _post method with AnkiConnect error."""
+        mock_response = AsyncMock()
+        mock_response.json = AsyncMock(return_value={"result": None, "error": "Test error"})
+        mock_response.raise_for_status = MagicMock()
+        
+        with patch.object(aiohttp.ClientSession, 'post') as mock_post:
+            mock_post.return_value.__aenter__.return_value = mock_response
+            
+            with pytest.raises(RuntimeError, match="AnkiConnect error: Test error"):
+                await deck._post("testAction")
+        
+        await deck.close()
+
+    @pytest.mark.asyncio
+    async def test_post_http_error(self, deck):
+        """Test _post method with HTTP error."""
+        mock_response = AsyncMock()
+        mock_response.raise_for_status = MagicMock(side_effect=aiohttp.ClientError("HTTP Error"))
+        
+        with patch.object(aiohttp.ClientSession, 'post') as mock_post:
+            mock_post.return_value.__aenter__.return_value = mock_response
+            
+            with pytest.raises(aiohttp.ClientError):
+                await deck._post("testAction")
+        
+        await deck.close()
+
+    def test_build_search_for_id(self, deck):
+        """Test _build_search_for_id method."""
+        query = deck._build_search_for_id(123)
+        assert query == 'deck:"TestDeck" note:"TestModel" id:123'
+
+    @pytest.mark.asyncio
+    async def test_fetch_single_feedback_success(self, deck):
+        """Test successful _fetch_single_feedback."""
+        # Mock the _post responses
+        with patch.object(deck, '_post') as mock_post:
+            # Setup mock responses for each call
+            mock_post.side_effect = [
+                [12345],  # findNotes response
+                [{  # notesInfo response
+                    "noteId": 12345,
+                    "modelName": "TestModel",
+                    "fields": {
+                        "Front": {"value": "Test question"},
+                        "Back": {"value": "Test answer"},
+                        "Topic": {"value": "Test topic"}
+                    }
+                }],
+                [54321, 54322],  # findCards response
+                [{  # cardsInfo response
+                    "suspended": False,
+                    "queue": 1,
+                    "flags": 2
+                }, {
+                    "suspended": True,
+                    "queue": -1,
+                    "flags": 1
+                }]
+            ]
+            
+            result = await deck._fetch_single_feedback(123)
+            
+            assert isinstance(result, AnkiNoteFeedback)
+            assert result.database_id == 123
+            assert result.anki_note_id == 12345
+            assert result.deck_name == "TestDeck"
+            assert result.model_name == "TestModel"
+            assert result.question == "Test question"
+            assert result.answer == "Test answer"
+            assert result.topic == "Test topic"
+            assert result.suspended is True  # One card is suspended
+            assert result.flag == 2  # Max flag value
+        
+        await deck.close()
+
+    @pytest.mark.asyncio
+    async def test_fetch_single_feedback_no_note(self, deck):
+        """Test _fetch_single_feedback when note is not found."""
+        with patch.object(deck, '_post') as mock_post:
+            mock_post.return_value = []  # Empty findNotes response
+            
+            result = await deck._fetch_single_feedback(123)
+            assert result is None
+        
+        await deck.close()
+
+    @pytest.mark.asyncio
+    async def test_fetch_single_feedback_no_cards(self, deck):
+        """Test _fetch_single_feedback when no cards exist."""
+        with patch.object(deck, '_post') as mock_post:
+            mock_post.side_effect = [
+                [12345],  # findNotes
+                [{  # notesInfo
+                    "noteId": 12345,
+                    "fields": {
+                        "Front": {"value": "Question"},
+                        "Back": {"value": "Answer"},
+                        "Topic": {"value": "Topic"}
+                    }
+                }],
+                [],  # No cards found
+            ]
+            
+            result = await deck._fetch_single_feedback(123)
+            
+            assert result is not None
+            assert result.suspended is False
+            assert result.flag == 0
+        
+        await deck.close()
+
+    @pytest.mark.asyncio
+    async def test_aget_feedback_for_database_ids(self, deck):
+        """Test aget_feedback_for_database_ids method."""
+        # Create mock feedback objects
+        feedback1 = AnkiNoteFeedback(
+            database_id=1,
+            anki_note_id=10001,
+            deck_name="TestDeck",
+            model_name="TestModel",
+            question="Q1",
+            answer="A1",
+            topic="T1",
+            suspended=False,
+            flag=0
+        )
+        feedback2 = AnkiNoteFeedback(
+            database_id=2,
+            anki_note_id=10002,
+            deck_name="TestDeck",
+            model_name="TestModel",
+            question="Q2",
+            answer="A2",
+            topic="T2",
+            suspended=True,
+            flag=1
+        )
+        
+        with patch.object(deck, '_fetch_single_feedback') as mock_fetch:
+            mock_fetch.side_effect = [feedback1, None, feedback2]  # Second ID returns None
+            
+            results = await deck.aget_feedback_for_database_ids([1, 2, 3])
+            
+            assert len(results) == 2  # None is filtered out
+            assert results[0] == feedback1
+            assert results[1] == feedback2
+            
+            # Verify all IDs were queried
+            assert mock_fetch.call_count == 3
+        
+        await deck.close()
+
+    @pytest.mark.asyncio
+    async def test_field_map_defaults(self):
+        """Test default field mapping."""
+        deck = AnkiConnectDeck(
+            deck_name="Test",
+            model_name="Test",
+        )
+        
+        assert deck.field_map["question"] == "Question"
+        assert deck.field_map["answer"] == "Answer"
+        assert deck.field_map["topic"] == "Topic"
+        
+        await deck.close()
+
+    @pytest.mark.asyncio
+    async def test_invalid_flag_handling(self, deck):
+        """Test handling of invalid flag values."""
+        with patch.object(deck, '_post') as mock_post:
+            mock_post.side_effect = [
+                [12345],  # findNotes
+                [{  # notesInfo
+                    "noteId": 12345,
+                    "fields": {"Front": {"value": "Q"}, "Back": {"value": "A"}}
+                }],
+                [54321],  # findCards
+                [{  # cardsInfo with invalid flag
+                    "suspended": False,
+                    "flags": "invalid"  # Non-integer flag
+                }]
+            ]
+            
+            result = await deck._fetch_single_feedback(123)
+            assert result.flag == 0  # Should default to 0
+        
+        await deck.close()

--- a/tests/unit/test_anki_models.py
+++ b/tests/unit/test_anki_models.py
@@ -1,0 +1,154 @@
+"""Unit tests for AnkiNoteFeedback model."""
+import pytest
+from pydantic import ValidationError
+
+from gpt_to_anki.anki_models import AnkiNoteFeedback
+
+
+class TestAnkiNoteFeedback:
+    """Test suite for AnkiNoteFeedback model."""
+
+    def test_create_with_all_fields(self):
+        """Test creating AnkiNoteFeedback with all fields."""
+        feedback = AnkiNoteFeedback(
+            database_id=1,
+            anki_note_id=10001,
+            deck_name="TestDeck",
+            model_name="TestModel",
+            question="Test Question",
+            answer="Test Answer",
+            topic="Test Topic",
+            suspended=True,
+            flag=2,
+        )
+        
+        assert feedback.database_id == 1
+        assert feedback.anki_note_id == 10001
+        assert feedback.deck_name == "TestDeck"
+        assert feedback.model_name == "TestModel"
+        assert feedback.question == "Test Question"
+        assert feedback.answer == "Test Answer"
+        assert feedback.topic == "Test Topic"
+        assert feedback.suspended is True
+        assert feedback.flag == 2
+
+    def test_create_with_defaults(self):
+        """Test creating AnkiNoteFeedback with default values."""
+        feedback = AnkiNoteFeedback(
+            database_id=1,
+            anki_note_id=10001,
+            deck_name="TestDeck",
+            model_name="TestModel",
+            question="Question",
+            answer="Answer",
+            # topic, suspended, and flag should use defaults
+        )
+        
+        assert feedback.topic == ""
+        assert feedback.suspended is False
+        assert feedback.flag == 0
+
+    def test_alias_support(self):
+        """Test that 'id' alias works for database_id."""
+        # Test creation with alias
+        feedback = AnkiNoteFeedback(
+            id=123,  # Using alias
+            anki_note_id=10001,
+            deck_name="TestDeck",
+            model_name="TestModel",
+            question="Q",
+            answer="A",
+        )
+        
+        assert feedback.database_id == 123
+        
+        # Test serialization uses alias
+        data = feedback.model_dump(mode='json', by_alias=True)
+        assert data["id"] == 123
+        assert "database_id" not in data
+
+    def test_from_orm_attributes(self):
+        """Test creating from ORM-like object."""
+        class MockORMObject:
+            database_id = 1
+            anki_note_id = 10001
+            deck_name = "TestDeck"
+            model_name = "TestModel"
+            question = "Q"
+            answer = "A"
+            topic = "T"
+            suspended = True
+            flag = 1
+        
+        feedback = AnkiNoteFeedback.model_validate(MockORMObject())
+        assert feedback.database_id == 1
+        assert feedback.suspended is True
+
+    def test_validation_errors(self):
+        """Test validation errors for required fields."""
+        # Missing required fields
+        with pytest.raises(ValidationError) as exc_info:
+            AnkiNoteFeedback(
+                database_id=1,
+                # Missing anki_note_id and other required fields
+            )
+        
+        errors = exc_info.value.errors()
+        assert any(e["loc"] == ("anki_note_id",) for e in errors)
+        assert any(e["loc"] == ("deck_name",) for e in errors)
+
+    def test_model_dump_json(self):
+        """Test JSON serialization."""
+        feedback = AnkiNoteFeedback(
+            database_id=1,
+            anki_note_id=10001,
+            deck_name="TestDeck",
+            model_name="TestModel",
+            question="Q",
+            answer="A",
+            topic="T",
+            suspended=True,
+            flag=1,
+        )
+        
+        # Test with alias
+        json_data = feedback.model_dump(mode='json', by_alias=True)
+        assert json_data["id"] == 1
+        assert json_data["suspended"] is True
+        assert json_data["flag"] == 1
+        
+        # Test without alias
+        json_data = feedback.model_dump(mode='json', by_alias=False)
+        assert json_data["database_id"] == 1
+
+    def test_equality(self):
+        """Test equality comparison between AnkiNoteFeedback instances."""
+        feedback1 = AnkiNoteFeedback(
+            database_id=1,
+            anki_note_id=10001,
+            deck_name="TestDeck",
+            model_name="TestModel",
+            question="Q",
+            answer="A",
+        )
+        
+        feedback2 = AnkiNoteFeedback(
+            database_id=1,
+            anki_note_id=10001,
+            deck_name="TestDeck",
+            model_name="TestModel",
+            question="Q",
+            answer="A",
+        )
+        
+        feedback3 = AnkiNoteFeedback(
+            database_id=2,  # Different ID
+            anki_note_id=10001,
+            deck_name="TestDeck",
+            model_name="TestModel",
+            question="Q",
+            answer="A",
+        )
+        
+        assert feedback1 == feedback2
+        assert feedback1 != feedback3

--- a/tests/unit/test_anki_sync.py
+++ b/tests/unit/test_anki_sync.py
@@ -1,0 +1,211 @@
+"""Unit tests for anki_sync module."""
+import pytest
+from unittest.mock import AsyncMock, MagicMock
+
+from gpt_to_anki.anki_sync import sync_feedback_for_context
+from gpt_to_anki.anki_base import AbstractAnkiDeck
+from gpt_to_anki.database import CardDatabase
+from gpt_to_anki.data_objects import Card
+from gpt_to_anki.anki_models import AnkiNoteFeedback
+
+
+class TestAnkiSync:
+    """Test suite for anki_sync functions."""
+
+    @pytest.fixture
+    def mock_deck(self):
+        """Create a mock AnkiDeck."""
+        deck = MagicMock(spec=AbstractAnkiDeck)
+        deck.aget_feedback_for_database_ids = AsyncMock()
+        return deck
+
+    @pytest.fixture
+    def mock_db(self):
+        """Create a mock CardDatabase."""
+        db = MagicMock(spec=CardDatabase)
+        db.aload_cards = AsyncMock()
+        db.asave_anki_feedback = AsyncMock()
+        return db
+
+    @pytest.mark.asyncio
+    async def test_sync_feedback_success(self, mock_deck, mock_db):
+        """Test successful feedback sync for a context."""
+        # Mock cards in the database
+        cards = [
+            Card(
+                database_id=1,
+                question="Q1",
+                answer="A1",
+                context="test_context",
+                topic="Topic1",
+                evaluation="good"
+            ),
+            Card(
+                database_id=2,
+                question="Q2",
+                answer="A2",
+                context="test_context",
+                topic="Topic2",
+                evaluation="good"
+            ),
+        ]
+        mock_db.aload_cards.return_value = cards
+
+        # Mock feedback from Anki
+        feedback = [
+            AnkiNoteFeedback(
+                database_id=1,
+                anki_note_id=10001,
+                deck_name="TestDeck",
+                model_name="TestModel",
+                question="Q1 Updated",
+                answer="A1 Updated",
+                topic="Topic1",
+                suspended=True,
+                flag=1
+            ),
+            AnkiNoteFeedback(
+                database_id=2,
+                anki_note_id=10002,
+                deck_name="TestDeck",
+                model_name="TestModel",
+                question="Q2",
+                answer="A2",
+                topic="Topic2",
+                suspended=False,
+                flag=0
+            ),
+        ]
+        mock_deck.aget_feedback_for_database_ids.return_value = feedback
+
+        # Run sync
+        result = await sync_feedback_for_context(mock_deck, mock_db, "test_context")
+
+        # Verify
+        assert result == 2
+        mock_db.aload_cards.assert_called_once_with("test_context")
+        mock_deck.aget_feedback_for_database_ids.assert_called_once_with([1, 2])
+        mock_db.asave_anki_feedback.assert_called_once_with(feedback)
+
+    @pytest.mark.asyncio
+    async def test_sync_feedback_no_cards(self, mock_deck, mock_db):
+        """Test sync when no cards exist for context."""
+        mock_db.aload_cards.return_value = []
+
+        result = await sync_feedback_for_context(mock_deck, mock_db, "empty_context")
+
+        assert result == 0
+        mock_db.aload_cards.assert_called_once_with("empty_context")
+        mock_deck.aget_feedback_for_database_ids.assert_not_called()
+        mock_db.asave_anki_feedback.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_sync_feedback_cards_without_ids(self, mock_deck, mock_db):
+        """Test sync when cards don't have database IDs."""
+        cards = [
+            Card(
+                database_id=None,  # No ID
+                question="Q1",
+                answer="A1",
+                context="test_context",
+                topic="Topic1",
+                evaluation="good"
+            ),
+        ]
+        mock_db.aload_cards.return_value = cards
+
+        result = await sync_feedback_for_context(mock_deck, mock_db, "test_context")
+
+        assert result == 0
+        mock_deck.aget_feedback_for_database_ids.assert_not_called()
+        mock_db.asave_anki_feedback.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_sync_feedback_no_anki_feedback(self, mock_deck, mock_db):
+        """Test sync when Anki returns no feedback."""
+        cards = [
+            Card(
+                database_id=1,
+                question="Q1",
+                answer="A1",
+                context="test_context",
+                topic="Topic1",
+                evaluation="good"
+            ),
+        ]
+        mock_db.aload_cards.return_value = cards
+        mock_deck.aget_feedback_for_database_ids.return_value = []
+
+        result = await sync_feedback_for_context(mock_deck, mock_db, "test_context")
+
+        assert result == 0
+        mock_db.asave_anki_feedback.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_sync_feedback_partial_results(self, mock_deck, mock_db):
+        """Test sync when only some cards have feedback in Anki."""
+        cards = [
+            Card(database_id=1, question="Q1", answer="A1", context="test", topic="T1", evaluation="good"),
+            Card(database_id=2, question="Q2", answer="A2", context="test", topic="T2", evaluation="good"),
+            Card(database_id=3, question="Q3", answer="A3", context="test", topic="T3", evaluation="good"),
+        ]
+        mock_db.aload_cards.return_value = cards
+
+        # Only feedback for cards 1 and 3
+        feedback = [
+            AnkiNoteFeedback(
+                database_id=1,
+                anki_note_id=10001,
+                deck_name="TestDeck",
+                model_name="TestModel",
+                question="Q1",
+                answer="A1",
+                topic="T1",
+            ),
+            AnkiNoteFeedback(
+                database_id=3,
+                anki_note_id=10003,
+                deck_name="TestDeck",
+                model_name="TestModel",
+                question="Q3",
+                answer="A3",
+                topic="T3",
+            ),
+        ]
+        mock_deck.aget_feedback_for_database_ids.return_value = feedback
+
+        result = await sync_feedback_for_context(mock_deck, mock_db, "test")
+
+        assert result == 2
+        mock_deck.aget_feedback_for_database_ids.assert_called_once_with([1, 2, 3])
+        mock_db.asave_anki_feedback.assert_called_once_with(feedback)
+
+    @pytest.mark.asyncio
+    async def test_sync_feedback_mixed_ids(self, mock_deck, mock_db):
+        """Test sync with mix of cards with and without database IDs."""
+        cards = [
+            Card(database_id=1, question="Q1", answer="A1", context="test", topic="T1", evaluation="good"),
+            Card(database_id=None, question="Q2", answer="A2", context="test", topic="T2", evaluation="good"),
+            Card(database_id=3, question="Q3", answer="A3", context="test", topic="T3", evaluation="good"),
+        ]
+        mock_db.aload_cards.return_value = cards
+
+        feedback = [
+            AnkiNoteFeedback(
+                database_id=1,
+                anki_note_id=10001,
+                deck_name="TestDeck",
+                model_name="TestModel",
+                question="Q1",
+                answer="A1",
+                topic="T1",
+            ),
+        ]
+        mock_deck.aget_feedback_for_database_ids.return_value = feedback
+
+        result = await sync_feedback_for_context(mock_deck, mock_db, "test")
+
+        assert result == 1
+        # Should only query for cards with IDs
+        mock_deck.aget_feedback_for_database_ids.assert_called_once_with([1, 3])
+        mock_db.asave_anki_feedback.assert_called_once_with(feedback)

--- a/tests/unit/test_database_anki_feedback.py
+++ b/tests/unit/test_database_anki_feedback.py
@@ -1,0 +1,266 @@
+"""Unit tests for anki_feedback database operations."""
+import pytest
+import tempfile
+import os
+from datetime import datetime
+
+from gpt_to_anki.database import CardDatabase, AnkiFeedbackRecord
+from gpt_to_anki.anki_models import AnkiNoteFeedback
+
+
+class TestAnkiFeedbackDatabaseOperations:
+    """Test suite for anki_feedback database operations."""
+
+    @pytest.fixture
+    async def db(self):
+        """Create a temporary database for testing."""
+        with tempfile.NamedTemporaryFile(suffix=".db", delete=False) as tmp:
+            db_path = tmp.name
+        
+        db = CardDatabase(db_path)
+        await db.ainit_database()
+        yield db
+        await db.aclose()
+        
+        # Cleanup
+        if os.path.exists(db_path):
+            os.unlink(db_path)
+
+    @pytest.fixture
+    def sample_feedback(self):
+        """Create sample AnkiNoteFeedback objects."""
+        return [
+            AnkiNoteFeedback(
+                database_id=1,
+                anki_note_id=10001,
+                deck_name="TestDeck1",
+                model_name="TestModel1",
+                question="Question 1",
+                answer="Answer 1",
+                topic="Topic 1",
+                suspended=False,
+                flag=0,
+            ),
+            AnkiNoteFeedback(
+                database_id=2,
+                anki_note_id=10002,
+                deck_name="TestDeck1",
+                model_name="TestModel1",
+                question="Question 2",
+                answer="Answer 2",
+                topic="Topic 2",
+                suspended=True,
+                flag=1,
+            ),
+            AnkiNoteFeedback(
+                database_id=3,
+                anki_note_id=10003,
+                deck_name="TestDeck2",
+                model_name="TestModel2",
+                question="Question 3",
+                answer="Answer 3",
+                topic="Topic 3",
+                suspended=False,
+                flag=2,
+            ),
+        ]
+
+    @pytest.mark.asyncio
+    async def test_save_and_load_anki_feedback(self, db, sample_feedback):
+        """Test saving and loading AnkiNoteFeedback."""
+        # Save feedback
+        await db.asave_anki_feedback(sample_feedback)
+        
+        # Load all feedback
+        loaded = await db.aload_anki_feedback([1, 2, 3])
+        assert len(loaded) == 3
+        
+        # Check each feedback is loaded correctly
+        for i, fb in enumerate(loaded):
+            expected = sample_feedback[i]
+            assert fb.database_id == expected.database_id
+            assert fb.anki_note_id == expected.anki_note_id
+            assert fb.deck_name == expected.deck_name
+            assert fb.model_name == expected.model_name
+            assert fb.question == expected.question
+            assert fb.answer == expected.answer
+            assert fb.topic == expected.topic
+            assert fb.suspended == expected.suspended
+            assert fb.flag == expected.flag
+
+    @pytest.mark.asyncio
+    async def test_load_partial_feedback(self, db, sample_feedback):
+        """Test loading only some feedback records."""
+        await db.asave_anki_feedback(sample_feedback)
+        
+        # Load only specific IDs
+        loaded = await db.aload_anki_feedback([1, 3])
+        assert len(loaded) == 2
+        assert loaded[0].database_id == 1
+        assert loaded[1].database_id == 3
+
+    @pytest.mark.asyncio
+    async def test_load_nonexistent_feedback(self, db):
+        """Test loading feedback for non-existent database IDs."""
+        loaded = await db.aload_anki_feedback([999, 1000])
+        assert len(loaded) == 0
+
+    @pytest.mark.asyncio
+    async def test_empty_feedback_list(self, db):
+        """Test handling empty feedback lists."""
+        # Save empty list
+        await db.asave_anki_feedback([])  # Should not raise error
+        
+        # Load empty list
+        loaded = await db.aload_anki_feedback([])
+        assert loaded == []
+
+    @pytest.mark.asyncio
+    async def test_update_existing_feedback(self, db, sample_feedback):
+        """Test updating existing feedback records."""
+        # Save initial feedback
+        await db.asave_anki_feedback(sample_feedback[:2])
+        
+        # Modify and save again
+        modified_feedback = [
+            AnkiNoteFeedback(
+                database_id=1,
+                anki_note_id=10001,
+                deck_name="UpdatedDeck",
+                model_name="UpdatedModel",
+                question="Updated Question 1",
+                answer="Updated Answer 1",
+                topic="Updated Topic 1",
+                suspended=True,  # Changed
+                flag=3,  # Changed
+            ),
+            AnkiNoteFeedback(
+                database_id=2,
+                anki_note_id=20002,  # Changed
+                deck_name="TestDeck1",
+                model_name="TestModel1",
+                question="Updated Question 2",  # Changed
+                answer="Answer 2",
+                topic="Topic 2",
+                suspended=False,  # Changed
+                flag=0,  # Changed
+            ),
+        ]
+        
+        await db.asave_anki_feedback(modified_feedback)
+        
+        # Load and verify updates
+        loaded = await db.aload_anki_feedback([1, 2])
+        assert len(loaded) == 2
+        
+        # Check first record
+        fb1 = next(fb for fb in loaded if fb.database_id == 1)
+        assert fb1.deck_name == "UpdatedDeck"
+        assert fb1.model_name == "UpdatedModel"
+        assert fb1.question == "Updated Question 1"
+        assert fb1.answer == "Updated Answer 1"
+        assert fb1.topic == "Updated Topic 1"
+        assert fb1.suspended is True
+        assert fb1.flag == 3
+        
+        # Check second record
+        fb2 = next(fb for fb in loaded if fb.database_id == 2)
+        assert fb2.anki_note_id == 20002
+        assert fb2.question == "Updated Question 2"
+        assert fb2.suspended is False
+        assert fb2.flag == 0
+
+    @pytest.mark.asyncio
+    async def test_mixed_insert_update(self, db, sample_feedback):
+        """Test mixed insert and update operations."""
+        # Save initial feedback
+        await db.asave_anki_feedback([sample_feedback[0]])
+        
+        # Save mix of existing and new
+        mixed_feedback = [
+            AnkiNoteFeedback(
+                database_id=1,  # Existing
+                anki_note_id=10001,
+                deck_name="UpdatedDeck",
+                model_name="TestModel1",
+                question="Updated Q1",
+                answer="Answer 1",
+                topic="Topic 1",
+                suspended=True,
+                flag=1,
+            ),
+            sample_feedback[1],  # New
+            sample_feedback[2],  # New
+        ]
+        
+        await db.asave_anki_feedback(mixed_feedback)
+        
+        # Verify all are saved
+        loaded = await db.aload_anki_feedback([1, 2, 3])
+        assert len(loaded) == 3
+        
+        # Verify update
+        fb1 = next(fb for fb in loaded if fb.database_id == 1)
+        assert fb1.deck_name == "UpdatedDeck"
+        assert fb1.question == "Updated Q1"
+        assert fb1.suspended is True
+
+    @pytest.mark.asyncio
+    async def test_database_not_initialized(self):
+        """Test operations on uninitialized database."""
+        with tempfile.NamedTemporaryFile(suffix=".db", delete=False) as tmp:
+            db_path = tmp.name
+        
+        db = CardDatabase(db_path)
+        # Don't call ainit_database()
+        
+        feedback = [
+            AnkiNoteFeedback(
+                database_id=1,
+                anki_note_id=10001,
+                deck_name="Test",
+                model_name="Test",
+                question="Q",
+                answer="A",
+                topic="T",
+                suspended=False,
+                flag=0,
+            )
+        ]
+        
+        # Operations should still work (ainit_database called internally)
+        await db.asave_anki_feedback(feedback)
+        loaded = await db.aload_anki_feedback([1])
+        assert len(loaded) == 1
+        
+        await db.aclose()
+        os.unlink(db_path)
+
+    @pytest.mark.asyncio
+    async def test_updated_at_timestamp(self, db):
+        """Test that updated_at timestamp is set correctly."""
+        feedback = AnkiNoteFeedback(
+            database_id=1,
+            anki_note_id=10001,
+            deck_name="Test",
+            model_name="Test",
+            question="Q",
+            answer="A",
+            topic="T",
+            suspended=False,
+            flag=0,
+        )
+        
+        # Save and check timestamp
+        before_save = datetime.utcnow()
+        await db.asave_anki_feedback([feedback])
+        
+        # Query directly to check timestamp
+        async with db.async_session() as session:
+            from sqlalchemy import select
+            stmt = select(AnkiFeedbackRecord).where(AnkiFeedbackRecord.database_id == 1)
+            result = await session.execute(stmt)
+            record = result.scalar_one()
+            
+            assert record.updated_at is not None
+            assert record.updated_at >= before_save


### PR DESCRIPTION
Adds Anki feedback synchronization to persist user-made changes and card status from Anki.

This feature allows users to save changes made to cards in Anki (e.g., modified fields, suspended status, flags) back into the application. It introduces an abstract `AnkiDeck` interface, a concrete `AnkiConnectDeck` implementation for fetching this data, and a new `anki_feedback` table in the database to store these updates.

---
<a href="https://cursor.com/background-agent?bcId=bc-12ddee64-3a2e-41d1-9528-6b03d0317c45">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-12ddee64-3a2e-41d1-9528-6b03d0317c45">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

